### PR TITLE
[AM-28] Support multi-line explanation of command option

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -20,7 +20,7 @@ func IncrementalSearch(inputs *string, manLists []string) []string {
 	for indexQuery := 0; indexQuery < len(separatedQuery); indexQuery++ {
 		resultCandidate := []string{}
 		for indexResult := 0; indexResult < len(result); indexResult++ {
-			if 0 < strings.Index(result[indexResult], separatedQuery[indexQuery]) {
+			if 0 <= strings.Index(result[indexResult], separatedQuery[indexQuery]) {
 				resultCandidate = append(resultCandidate, result[indexResult])
 			}
 		}

--- a/iocontrol/iocontrol.go
+++ b/iocontrol/iocontrol.go
@@ -47,7 +47,9 @@ func RenderQuery(inputs *string) {
 }
 
 func RenderResult(result []string) {
+	fmt.Println("----------")
 	for i := 0; i < len(result); i++ {
 		fmt.Printf("\r%s\n", result[i])
+		fmt.Println("----------")
 	}
 }


### PR DESCRIPTION
```go
manLists := [...]string{"hoge\nfuga", "piyo"}
```
のように、複数行のコマンド説明文に対して検索ができることを確認しました。

動作確認はミーティング時にも行う予定です。