### PR TITLE
[AM-33] feed page

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -2,26 +2,31 @@ package filter
 
 import (
 	"strings"
+
+	"github.com/aman/modules"
 )
 
 /*
 @param inputs   クエリ
-@param manLists オプションとオプション説明が格納された配列
+@param manLists オプションとオプション説明が格納された文字列と、各オプション説明の行数の配列
 @description
 1. クエリを空白類で区切って配列化する
 2. 区切ったクエリを1要素ごとに取り出す
 3. 取り出したクエリが、オプション説明文字列の部分文字列なら、次回に取り出すクエリに対する検索対象として、オプション説明文字列を配列に格納する
 4. 区切ったクエリをすべて取り出し終えるか、次回の検索対象のオプション説明文字列が無くなるまで2.と3.を繰り返す 
 */
-func IncrementalSearch(inputs *string, manLists []string) []string {
+func IncrementalSearch(inputs *string, manLists []modules.ManData) []modules.ManData {
 	separatedQuery := strings.Fields(*inputs)
 	result := manLists
 
 	for indexQuery := 0; indexQuery < len(separatedQuery); indexQuery++ {
-		resultCandidate := []string{}
+		resultCandidate := []modules.ManData{}
 		for indexResult := 0; indexResult < len(result); indexResult++ {
-			if 0 <= strings.Index(result[indexResult], separatedQuery[indexQuery]) {
-				resultCandidate = append(resultCandidate, result[indexResult])
+			if 0 <= strings.Index(result[indexResult].Contents, separatedQuery[indexQuery]) {
+				resultCandidate = append(resultCandidate, modules.ManData {
+					Contents: result[indexResult].Contents,
+					LineNumber: result[indexResult].LineNumber,
+				})
 			}
 		}
 		result = resultCandidate
@@ -29,5 +34,5 @@ func IncrementalSearch(inputs *string, manLists []string) []string {
 			break
 		}
 	}
-	return result[:]
+	return result
 }

--- a/iocontrol/iocontrol.go
+++ b/iocontrol/iocontrol.go
@@ -1,13 +1,40 @@
 package iocontrol
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/aman/modules"
 	"github.com/nsf/termbox-go"
 )
+
+/*
+ * height  ウィンドウの高さ
+ * page    現在のページ番号 定義域は[0, maxPage]
+ * maxPage 最大ページ番号
+ */
+type IoController struct {
+	height int
+	page int
+	maxPage int
+}
+
+/*
+ * @param manLists オプションとオプション説明が格納された文字列と、各オプション説明の行数の配列
+ * @description IoControllerのコンストラクタ
+ */
+func NewIoController(manLists []modules.ManData) *IoController {
+	_, height := termbox.Size()
+	iocontroller := IoController{
+		height: height,
+		page: 0,
+		maxPage: 0,
+	}
+	return &iocontroller
+}
 
 func DeleteInput(inputs *string) {
 	var space = ""
@@ -20,7 +47,7 @@ func DeleteInput(inputs *string) {
 	}
 }
 
-func ReceiveKeys(inputs *string) int {
+func (iocontroller *IoController) ReceiveKeys(inputs *string) int {
 	switch ev := termbox.PollEvent(); ev.Type {
 	case termbox.EventKey:
 		switch ev.Key {
@@ -32,7 +59,18 @@ func ReceiveKeys(inputs *string) int {
 				DeleteInput(inputs)
 			case termbox.KeyBackspace2:
 				DeleteInput(inputs)
+			case termbox.KeyArrowRight:
+				iocontroller.page++
+				if iocontroller.maxPage < iocontroller.page {
+					iocontroller.page = iocontroller.maxPage
+				}
+			case termbox.KeyArrowLeft:
+				iocontroller.page--
+				if iocontroller.page < 0 {
+					iocontroller.page = 0
+				}
 			default:
+				iocontroller.page = 0
 				*inputs += string(ev.Ch)
 		}
 	default:
@@ -47,20 +85,68 @@ func RenderQuery(inputs *string) {
 	fmt.Printf("\r> %s\n", *inputs)
 }
 
-func RenderResult(result []string) {
-	_, height := termbox.Size()
+func (iocontroller *IoController) RenderResult(result []modules.ManData, pageList []int) {
 	var row = 0
+	fmt.Printf("%d/%d", iocontroller.page+1, iocontroller.maxPage+1)
 	fmt.Println("----------")
 	row++
-	if height <= row {
+	if iocontroller.height <= row {
 		return
 	}
-	for i := 0; i < len(result); i++ {
-		row += strings.Count(result[i], "\n") + 2
-		if height <= row {
+
+	if len(result) == 0 {
+		return
+	}
+
+	for i := pageList[iocontroller.page]; i < pageList[iocontroller.page + 1]; i++ {
+		row += strings.Count(result[i].Contents, "\n") + 2
+		if iocontroller.height <= row {
 			return
 		}
-		fmt.Printf("\r%s\n", result[i])
+		fmt.Printf("\r%s\n", result[i].Contents)
 		fmt.Println("----------")
 	}
+}
+
+/*
+ * @param manLists オプションとオプション説明が格納された文字列と、各オプション説明の行数の配列
+ * @description 各ページの先頭となるオプション配列manListsのindex番号が格納された配列を生成する
+ */
+func (iocontroller *IoController) LocatePages(manLists []modules.ManData) []int {
+	var maxLineNumber = -1
+	pageList := []int{0}
+	// >行と---の2行
+	var lineCount = 2
+	var page = 0
+	iocontroller.maxPage = 0
+
+	for i := 0; i < len(manLists); i++ {
+		// for文を抜けた後に、ウィンドウの高さが低すぎて描画できないかを判定するために、
+		// 一番行数の多いオプション説明文の行数を求める
+		if maxLineNumber < manLists[i].LineNumber {
+			maxLineNumber = manLists[i].LineNumber
+		}
+
+		// ウィンドウの高さをオーバーしてしまう場合、次のページにオプション説明を表示する
+		if iocontroller.height < lineCount + manLists[i].LineNumber {
+			lineCount = 2
+			page++
+			pageList = append(pageList, i)
+			if iocontroller.maxPage < page {
+				iocontroller.maxPage = page
+			}
+		}
+
+		lineCount += manLists[i].LineNumber
+
+		if i == len(manLists) - 1 {
+			pageList = append(pageList, i + 1)
+		}
+	}
+
+	if iocontroller.height < maxLineNumber {
+		panic(errors.New("Window height is too small"))
+	}
+
+	return pageList
 }

--- a/main.go
+++ b/main.go
@@ -23,14 +23,17 @@ func main() {
 	manLists := modules.AnalyzeOutput(commandResult)
 	var inputs = ""
 
+	iocontroller := iocontrol.NewIoController(manLists)
 	iocontrol.RenderQuery(&inputs)
-	iocontrol.RenderResult(manLists[:])
+	pageList := iocontroller.LocatePages(manLists)
+	iocontroller.RenderResult(manLists, pageList[:])
 	for {
-		if iocontrol.ReceiveKeys(&inputs) == -1 {
+		if iocontroller.ReceiveKeys(&inputs) == -1 {
 			return
 		}
 		iocontrol.RenderQuery(&inputs)
-		result := filter.IncrementalSearch(&inputs, manLists[:])
-		iocontrol.RenderResult(result[:])
+		result := filter.IncrementalSearch(&inputs, manLists)
+		pageList = iocontroller.LocatePages(result)
+		iocontroller.RenderResult(result, pageList[:])
 	}
 }

--- a/modules/input.go
+++ b/modules/input.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+type ManData struct {
+	Contents string
+	LineNumber int
+}
+
 /**
 * コマンドライン引数を取得
  */
@@ -51,7 +56,7 @@ func ExecMan(args []string) string {
 * @params output manコマンド実行結果
 * @return オプションテキストリスト
 **/
-func AnalyzeOutput(output string) []string {
+func AnalyzeOutput(output string) []ManData {
 	// === 条件 ===
 	// ハイフンまたはダブルハイフンで始まる英単語
 	var splitOutputs []string = strings.Split(output, "\n")
@@ -62,7 +67,7 @@ func AnalyzeOutput(output string) []string {
 
 	// buffer の方が string結合より効率が良い
 	var buffer bytes.Buffer // オプション説明のブロックを入れる変数
-	var results []string
+	var results []ManData
 
 	// オプション条件を満たしているかをチェック
 	var isOptionText = func(line string) bool {
@@ -121,7 +126,10 @@ func AnalyzeOutput(output string) []string {
 		} else {
 			// 改行だった場合次のオプションを探す
 			if len(line) == 0 {
-				results = append(results, buffer.String())
+				results = append(results, ManData {
+					Contents: buffer.String(),
+					LineNumber: strings.Count(buffer.String(), "\n") + 2,
+				})
 				buffer.Reset()
 				isFinding = true
 				continue


### PR DESCRIPTION
### 方針
1. manListを全舐めして、各manの行数を得る。(最初にmanList生成するときに得られると計算量減らせる)
1. 最大行数が現在のウィンドウ高さを超えていた場合、"高さ足りない"とエラー表示。もしくは、説明が途切れてもいいからウィンドウ高さの範囲内で表示する。
1. manList行数リストを全舐めし、各ページの先頭となるmanListのindexを格納するpageListを生成する。このとき、ウィンドウの高さとmanの行数の場合分けに注意する。
1. pageListを参照し、表示する。今pページ目(0ページスタート)なら、manList[pageList[p]], ..., manList[pageList[p+1]-1]までを表示する。

### イベント処理
- ←/→キー押下時に、ページ番号の変更及び、上記4. を実行。
- ウィンドウの高さ変更時、上記2. から実行。
- 任意のキー入力時、manListが更新されるのと同時に行数リストもフィルタリングしておくことで、上記2. から実行可能。manListはstringとint持つstructにしても良いかも。

### Merge順
https://github.com/naruhiyo/aman/pull/5 を先にMergeする