### PR TITLE
Fix #9

### DIFF
--- a/modules/input.go
+++ b/modules/input.go
@@ -83,7 +83,5 @@ func AnalyzeOutput(output string) []string {
 		}
 	}
 
-	results = append(results, buffer.String())
-
 	return results
 }


### PR DESCRIPTION
削除行時点で`buffer.String()`は空文字となり、不要だと判断したため削除しました。

ページ送り機能を利用して、最終ページの出力結果を確認した内容を下記に記します。
### 削除前
```console
>
3/3----------
       --glob-pathspecs
           Add "glob" magic to all pathspec. This is equivalent to setting the
           GIT_GLOB_PATHSPECS environment variable to 1. Disabling globbing on
           individual pathspecs can be done using pathspec magic ":(literal)"
----------
       --noglob-pathspecs
           Add "literal" magic to all pathspec. This is equivalent to setting
           the GIT_NOGLOB_PATHSPECS environment variable to 1. Enabling
           globbing on individual pathspecs can be done using pathspec magic
           ":(glob)"
----------
       --icase-pathspecs
           Add "icase" magic to all pathspec. This is equivalent to setting
           the GIT_ICASE_PATHSPECS environment variable to 1.
----------
       --no-optional-locks
           Do not perform optional operations that require locks. This is
           equivalent to setting the GIT_OPTIONAL_LOCKS to 0.
----------
       --list-cmds=group[,group...]
           List commands by group. This is an internal/experimental option and
           may change or be removed in the future. Supported groups are:
           builtins, parseopt (builtin commands that use parse-options), main
           (all commands in libexec directory), others (all other commands in
           $PATH that have git- prefix), list-<category> (see categories in
           command-list.txt), nohelpers (exclude helper commands), alias and
           config (retrieve command list from config variable
           completion.commands)
----------
           --namespace command-line option also sets this value.
----------

----------
```

### 削除後
```console
>
3/3----------
       --glob-pathspecs
           Add "glob" magic to all pathspec. This is equivalent to setting the
           GIT_GLOB_PATHSPECS environment variable to 1. Disabling globbing on
           individual pathspecs can be done using pathspec magic ":(literal)"
----------
       --noglob-pathspecs
           Add "literal" magic to all pathspec. This is equivalent to setting
           the GIT_NOGLOB_PATHSPECS environment variable to 1. Enabling
           globbing on individual pathspecs can be done using pathspec magic
           ":(glob)"
----------
       --icase-pathspecs
           Add "icase" magic to all pathspec. This is equivalent to setting
           the GIT_ICASE_PATHSPECS environment variable to 1.
----------
       --no-optional-locks
           Do not perform optional operations that require locks. This is
           equivalent to setting the GIT_OPTIONAL_LOCKS to 0.
----------
       --list-cmds=group[,group...]
           List commands by group. This is an internal/experimental option and
           may change or be removed in the future. Supported groups are:
           builtins, parseopt (builtin commands that use parse-options), main
           (all commands in libexec directory), others (all other commands in
           $PATH that have git- prefix), list-<category> (see categories in
           command-list.txt), nohelpers (exclude helper commands), alias and
           config (retrieve command list from config variable
           completion.commands)
----------
           --namespace command-line option also sets this value.
----------
```