### PR TITLE
[AM-41] Change page number position

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -15,8 +15,8 @@ import (
 3. 取り出したクエリが、オプション説明文字列の部分文字列なら、次回に取り出すクエリに対する検索対象として、オプション説明文字列を配列に格納する
 4. 区切ったクエリをすべて取り出し終えるか、次回の検索対象のオプション説明文字列が無くなるまで2.と3.を繰り返す
 */
-func IncrementalSearch(inputs *string, manLists []modules.ManData) []modules.ManData {
-	separatedQuery := strings.Fields(*inputs)
+func IncrementalSearch(inputs string, manLists []modules.ManData) []modules.ManData {
+	separatedQuery := strings.Fields(inputs)
 	result := manLists
 
 	for indexQuery := 0; indexQuery < len(separatedQuery); indexQuery++ {

--- a/main.go
+++ b/main.go
@@ -31,8 +31,6 @@ func main() {
 	var commandResult string = modules.ExecMan(args)
 
 	var manLists []modules.ManData = modules.AnalyzeOutput(commandResult)
-	// 入力キーワード
-	var inputs string = ""
 	// 選択位置
 	var selectedPos int = 0
 	// 検索結果
@@ -41,18 +39,19 @@ func main() {
 	var stackOptions []string
 
 	iocontroller := iocontrol.NewIoController(result)
-	iocontrol.RenderQuery(&inputs)
+	iocontroller.RenderQuery()
 	pageList := iocontroller.LocatePages(result)
+	iocontroller.RenderPageNumber()
 	iocontroller.RenderResult(selectedPos, result, pageList[:])
 loop:
 	for {
-		var keyStatus int = iocontroller.ReceiveKeys(&inputs, &selectedPos)
-		iocontrol.RenderQuery(&inputs)
+		var keyStatus int = iocontroller.ReceiveKeys(&selectedPos)
+		iocontroller.RenderQuery()
 
 		switch keyStatus {
 		// 毎回 man 結果に対して検索を行う
 		case ANYKEY:
-			result = filter.IncrementalSearch(&inputs, manLists)
+			result = filter.IncrementalSearch(iocontroller.GetQuery(), manLists)
 		case ARROW_UP:
 			if selectedPos > 0 {
 				selectedPos--
@@ -68,6 +67,7 @@ loop:
 			break loop
 		}
 		pageList = iocontroller.LocatePages(result)
+		iocontroller.RenderPageNumber()
 		iocontroller.RenderResult(selectedPos, result, pageList[:])
 	}
 


### PR DESCRIPTION
### 概要
- JIRA: [AM-41](https://naruhiyo.atlassian.net/browse/AM-41)
- ページ番号は1行目の右端に表示されるように修正
- 上記修正の過程で`iocontroller`に`width`, `query`を追加

### 動作確認画面
いづれの場合も、1行目の右端にページ番号が表示されている。
#### query入力前
<img src="https://user-images.githubusercontent.com/28133383/97390553-853dcd80-1920-11eb-9b4e-233faa17e0f3.png" width="70%">

#### query入力後
<img src="https://user-images.githubusercontent.com/28133383/97390608-9e467e80-1920-11eb-8586-6a010a2b96b3.png" width="70%">
