### PR TITLE
Fix #48

### DIFF
--- a/implement/io/input.go
+++ b/implement/io/input.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	sio "aman/struct/io"
 	"github.com/mattn/go-runewidth"
 	"github.com/nsf/termbox-go"
+
+	sio "aman/struct/io"
 )
 
 type InputStruct sio.InputStruct

--- a/implement/model/man_data_object.go
+++ b/implement/model/man_data_object.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"strings"
 
-	smodel "aman/struct/model"
 	"github.com/nsf/termbox-go"
+
+	smodel "aman/struct/model"
 )
 
 type ManDataObjectStruct smodel.ManDataObject

--- a/implement/util/command.go
+++ b/implement/util/command.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	sutil "aman/struct/util"
-
 	"github.com/go-vgo/robotgo"
 	"github.com/mattn/go-pipeline"
+
+	sutil "aman/struct/util"
 )
 
 type CommandStruct sutil.CommandStruct

--- a/implement/util/command.go
+++ b/implement/util/command.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	sutil "aman/struct/util"
+
 	"github.com/go-vgo/robotgo"
 	"github.com/mattn/go-pipeline"
 )
@@ -40,7 +41,7 @@ func (myself *CommandStruct) ExecMan(commands []string) {
 	)
 
 	if err != nil {
-		panic(errors.New("Error: No results"))
+		panic(errors.New("No man command results"))
 	}
 
 	myself.ManResult = string(out)

--- a/implement/window/window.go
+++ b/implement/window/window.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	imodel "aman/implement/model"
-	swindow "aman/struct/window"
 	"github.com/mattn/go-runewidth"
 	"github.com/nsf/termbox-go"
+
+	imodel "aman/implement/model"
+	swindow "aman/struct/window"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -5,14 +5,13 @@ package main
  * s*** : 構造体モジュール
  */
 import (
-	"log"
-	"runtime/debug"
-
 	iio "aman/implement/io"
 	imodel "aman/implement/model"
 	ipagination "aman/implement/pagination"
 	iutil "aman/implement/util"
 	iwindow "aman/implement/window"
+	"fmt"
+
 	"github.com/nsf/termbox-go"
 )
 
@@ -49,7 +48,7 @@ func postExecMain() {
 	if r := recover(); r != nil {
 		var recoverCommand *iutil.CommandStruct = iutil.NewCommand()
 		recoverCommand.ExecWithStdin("stty", "sane")
-		log.Printf("Recovered. %v\nStack:\n%s", r, debug.Stack())
+		fmt.Printf("Terminated with error: %v\n", r)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,14 +5,15 @@ package main
  * s*** : 構造体モジュール
  */
 import (
+	"fmt"
+
+	"github.com/nsf/termbox-go"
+
 	iio "aman/implement/io"
 	imodel "aman/implement/model"
 	ipagination "aman/implement/pagination"
 	iutil "aman/implement/util"
 	iwindow "aman/implement/window"
-	"fmt"
-
-	"github.com/nsf/termbox-go"
 )
 
 /**


### PR DESCRIPTION
### 内容
Fix https://github.com/naruhiyo/aman/issues/48

### 動作確認項目
<img width="774" alt="スクリーンショット 2020-12-29 17 47 44" src="https://user-images.githubusercontent.com/16721102/103271611-0dfae780-49fe-11eb-9406-48fa83a9556d.png">


### 備考
- `log` はタイムスタンプが出力されるので、`fmt` に切り替え
- `stack trace` はデバッグにしか必要がないので削除
- 現状、man の実行結果がなければ、 panic が実行されるため、特別な対応は必要なさそうです。
